### PR TITLE
Hotfix: incorrect handler for service restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: "Restart sshd"
   ansible.builtin.service:
-    name: sshd
+    name: ssh
     state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,5 @@
   ansible.builtin.service:
     name: ssh
     state: restarted
+    enabled: true
+    daemon_reload: true


### PR DESCRIPTION
- **Fix incorrect systemd service name reference**
- **Set the `ssh` service's `enabled` and `daemon_reload` options to `true`**
